### PR TITLE
Small changes in Assignment 2 (step-by-step)

### DIFF
--- a/Assignment02/step-by-step.md
+++ b/Assignment02/step-by-step.md
@@ -74,7 +74,7 @@ First you're going to change the code so it calls the Dapr sidecar:
    http://localhost:<daprPort>/v1.0/invoke/<appId>/method/<method-name>
    ```
 
-   You can substitute the placeholders in this URL with values for the VehicleRegistrationService, this yields the following URL:
+   You can substitute the placeholders in this URL with the appropriate values so the FineCollectionService's sidecar can call the the VehicleRegistrationService, this yields the following URL:
 
    ```http
    http://localhost:3601/v1.0/invoke/vehicleregistrationservice/method/vehicleinfo/{licenseNumber}

--- a/Assignment02/step-by-step.md
+++ b/Assignment02/step-by-step.md
@@ -74,7 +74,7 @@ First you're going to change the code so it calls the Dapr sidecar:
    http://localhost:<daprPort>/v1.0/invoke/<appId>/method/<method-name>
    ```
 
-   You can substitute the placeholders in this URL with values for the FineCollectionService, this yields the following URL:
+   You can substitute the placeholders in this URL with values for the VehicleRegistrationService, this yields the following URL:
 
    ```http
    http://localhost:3601/v1.0/invoke/vehicleregistrationservice/method/vehicleinfo/{licenseNumber}
@@ -92,7 +92,7 @@ First you're going to change the code so it calls the Dapr sidecar:
    }
    ```
 
-   > It's important to really grasp the sidecar pattern used by Dapr. In this case, the FineCollectionService calls the VehicleRegistrationService by **calling its own dapr sidecar**! The FineCollectionService doesn't need to know anymore where the VehicleRegistrationService lives because its Dapr sidecar will take care of that. It will find it based on the `app-id` specified in the URL and call the target service's sidecar.
+   > It's important to really grasp the sidecar pattern used by Dapr. In this case, the FineCollectionService calls the VehicleRegistrationService by **calling its own Dapr sidecar**! The FineCollectionService doesn't need to know anymore where the VehicleRegistrationService lives because its Dapr sidecar will take care of that. It will find it based on the `app-id` specified in the URL and call the target service's sidecar.
 
 1. Open a **new** terminal window in VS Code and make sure the current folder is `src/FineCollectionService`.
 

--- a/Assignment02/step-by-step.md
+++ b/Assignment02/step-by-step.md
@@ -11,7 +11,7 @@ This assignment targets number **1** in the end-state setup:
 
 <img src="../img/dapr-setup.png" style="zoom: 67%;" />
 
-### Step 1: Start the VehicleRegistrationService with Dapr
+## Step 1: Start the VehicleRegistrationService with Dapr
 
 In assignment 1, you started all the services using `dotnet run`. When you want to run a service with a Dapr sidecar that handles its communication, you need to start it using the Dapr CLI. There are a couple of things you need to specify when starting the service:
 


### PR DESCRIPTION
Three minor textual changes:

- All other "Step" headers were at H2, only this one at H3
- I believe the text referred to the wrong application: it read FineCollectionService, but that's the application where the students are working on, while the context suggested it should read VehicleRegistrationService
- dapr deserves a uppercase D ;-)