### PR TITLE
Add recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "vscjava.vscode-java-pack",
+        "humao.rest-client",
+        "ms-dotnettools.csharp"
+    ]
+}


### PR DESCRIPTION
This pull request adds a set of recommendations for VS Code plugins & extensions to use. It uses the [**.vscode/extensions.json**](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions) for that.