### PR TITLE
Fix python3 command line instruction

### DIFF
--- a/Assignment06/step-by-step-python.md
+++ b/Assignment06/step-by-step-python.md
@@ -245,7 +245,7 @@ using the `--components-path` flag so Dapr will use these config files:
 1. Start the simulation:
 
    ```console
-   python simulation
+   python3 simulation
    ```
 
 You should see the same logs as before.


### PR DESCRIPTION
There's one command that uses `python` instead of `python3`. This breaks on Linux.